### PR TITLE
Add ChatGPT RTL Fixer Chrome extension

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,0 +1,189 @@
+// ChatGPT RTL Fixer (FA/EN)
+// Corrects mixed Persian/Arabic (RTL) and English (LTR) text on ChatGPT.
+// Assumptions: heuristic detection based on character counts; existing formatting is preserved.
+// Quick install: Chrome > Extensions > Developer mode > Load unpacked > select this folder.
+
+(() => {
+  const SETTINGS_DEFAULT = {
+    enabled: true,
+    mode: 'auto', // auto | dir-only | wrap-latin
+    skipCode: true,
+  };
+
+  let settings = { ...SETTINGS_DEFAULT };
+
+  const BLOCK_SELECTOR = '.markdown, .prose, div[data-message-id], div[data-testid="conversation-turn"]';
+  const SKIP_SELECTOR = 'pre,code,kbd,samp,mjx-container,.katex,table,[contenteditable]';
+  const rtlRegex = /[\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF]/;
+  const ltrRegex = /[A-Za-z0-9]/;
+
+  function detectDominantScript(text) {
+    let rtl = 0,
+      ltr = 0;
+    for (const ch of text) {
+      if (rtlRegex.test(ch)) rtl++;
+      else if (ltrRegex.test(ch)) ltr++;
+    }
+    return rtl > ltr ? 'rtl' : 'ltr';
+  }
+
+  function splitIntoRuns(text) {
+    const runs = [];
+    let current = { type: null, text: '' };
+    for (const ch of text) {
+      const type = rtlRegex.test(ch)
+        ? 'rtl'
+        : ltrRegex.test(ch)
+        ? 'ltr'
+        : 'neutral';
+      if (current.type === type) current.text += ch;
+      else {
+        if (current.type !== null) runs.push(current);
+        current = { type, text: ch };
+      }
+    }
+    if (current.type !== null) runs.push(current);
+    return runs;
+  }
+
+  function applyDirectionFix(block) {
+    if (block.dataset.rtlFixed === '1') return;
+    const walker = document.createTreeWalker(block, NodeFilter.SHOW_TEXT, {
+      acceptNode(node) {
+        if (!node.nodeValue.trim()) return NodeFilter.FILTER_REJECT;
+        const parent = node.parentElement;
+        if (!parent) return NodeFilter.FILTER_REJECT;
+        if (parent.closest(SKIP_SELECTOR)) return NodeFilter.FILTER_REJECT;
+        if (parent.closest('bdi')) return NodeFilter.FILTER_REJECT;
+        return NodeFilter.FILTER_ACCEPT;
+      },
+    });
+    const textNodes = [];
+    let combined = '';
+    while (walker.nextNode()) {
+      textNodes.push(walker.currentNode);
+      combined += walker.currentNode.nodeValue;
+    }
+    if (!textNodes.length) return;
+
+    const dominant = detectDominantScript(combined);
+    block.style.direction = dominant === 'rtl' ? 'rtl' : 'ltr';
+    block.style.textAlign = 'start';
+    block.style.unicodeBidi = 'isolate';
+
+    if (settings.mode === 'dir-only') {
+      block.dataset.rtlFixed = '1';
+      return;
+    }
+
+    textNodes.forEach((node) => {
+      const runs = splitIntoRuns(node.nodeValue);
+      const frag = document.createDocumentFragment();
+      runs.forEach((run) => {
+        if (run.type === 'neutral') {
+          frag.appendChild(document.createTextNode(run.text));
+        } else if (
+          dominant === 'rtl' &&
+          run.type === 'ltr' &&
+          (settings.mode === 'auto' || settings.mode === 'wrap-latin')
+        ) {
+          const bdi = document.createElement('bdi');
+          bdi.setAttribute('dir', 'ltr');
+          bdi.textContent = run.text;
+          frag.appendChild(bdi);
+        } else if (
+          dominant === 'ltr' &&
+          run.type === 'rtl' &&
+          settings.mode === 'auto'
+        ) {
+          const bdi = document.createElement('bdi');
+          bdi.setAttribute('dir', 'rtl');
+          bdi.textContent = run.text;
+          frag.appendChild(bdi);
+        } else {
+          frag.appendChild(document.createTextNode(run.text));
+        }
+      });
+      node.parentNode.replaceChild(frag, node);
+    });
+    block.dataset.rtlFixed = '1';
+  }
+
+  let processTimer = null;
+  function processAll() {
+    if (!settings.enabled) return;
+    document.querySelectorAll(BLOCK_SELECTOR).forEach(applyDirectionFix);
+  }
+
+  function scheduleProcess() {
+    if (!settings.enabled) return;
+    clearTimeout(processTimer);
+    processTimer = setTimeout(() => {
+      (window.requestIdleCallback || ((fn) => setTimeout(fn, 0)))(processAll);
+    }, 150);
+  }
+
+  function observeMutations() {
+    const observer = new MutationObserver((mutations) => {
+      if (!settings.enabled) return;
+      mutations.forEach((m) => {
+        if (m.type === 'childList') {
+          m.addedNodes.forEach((n) => {
+            if (n.nodeType === 1) {
+              n.querySelectorAll &&
+                n.querySelectorAll(BLOCK_SELECTOR).forEach((el) =>
+                  el.removeAttribute('data-rtl-fixed')
+                );
+            }
+          });
+        } else if (m.type === 'characterData') {
+          const block =
+            m.target.parentElement &&
+            m.target.parentElement.closest(BLOCK_SELECTOR);
+          if (block) block.removeAttribute('data-rtl-fixed');
+        }
+      });
+      scheduleProcess();
+    });
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
+  }
+
+  let lastURL = location.href;
+  setInterval(() => {
+    if (location.href !== lastURL) {
+      lastURL = location.href;
+      document
+        .querySelectorAll(BLOCK_SELECTOR)
+        .forEach((el) => el.removeAttribute('data-rtl-fixed'));
+      scheduleProcess();
+    }
+  }, 1000);
+
+  chrome.runtime.onMessage.addListener((msg) => {
+    if (msg.type === 'settings') {
+      settings = { ...settings, ...msg.settings };
+      if (settings.enabled) scheduleProcess();
+    }
+  });
+
+  observeMutations();
+  chrome.runtime.sendMessage(
+    { type: 'getSettings', host: location.hostname },
+    (res) => {
+      if (res && res.settings) {
+        settings = { ...settings, ...res.settings };
+        if (settings.enabled) scheduleProcess();
+      }
+    }
+  );
+
+  // Acceptance tests (manual):
+  // 1. Mixed Persian & English: "این یک test ساده است 123".
+  // 2. English paragraph with single Persian word: "This is an مثال paragraph.".
+  // 3. Code block: `console.log("سلام");` is untouched.
+  // 4. New or edited ChatGPT messages auto-correct.
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,36 @@
+{
+  "manifest_version": 3,
+  "name": "ChatGPT RTL Fixer (FA/EN)",
+  "description": "Fixes mixed Persian/Arabic and English text direction on ChatGPT.",
+  "version": "1.0.0",
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "permissions": ["storage", "tabs", "scripting"],
+  "host_permissions": [
+    "https://chat.openai.com/*",
+    "https://chatgpt.com/*"
+  ],
+  "background": {
+    "service_worker": "service_worker.js"
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "https://chat.openai.com/*",
+        "https://chatgpt.com/*"
+      ],
+      "js": ["content.js"],
+      "css": ["styles.css"],
+      "run_at": "document_idle"
+    }
+  ],
+  "commands": {
+    "toggle-extension": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+R"
+      },
+      "description": "Toggle ChatGPT RTL Fixer"
+    }
+  }
+}

--- a/popup.css
+++ b/popup.css
@@ -1,0 +1,14 @@
+body {
+  min-width: 200px;
+  font-family: sans-serif;
+  padding: 10px;
+}
+
+.row {
+  margin-top: 8px;
+}
+
+label {
+  display: block;
+  margin-bottom: 6px;
+}

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <link rel="stylesheet" href="popup.css" />
+  <title>ChatGPT RTL Fixer</title>
+</head>
+<body>
+  <label><input type="checkbox" id="enabled" /> Enable on this site</label>
+
+  <div class="row">
+    <label for="mode">Mode</label>
+    <select id="mode">
+      <option value="auto">Auto (dir + bdi)</option>
+      <option value="dir-only">Dir only</option>
+      <option value="wrap-latin">Wrap Latin in RTL</option>
+    </select>
+  </div>
+
+  <label><input type="checkbox" id="skipCode" /> Don't touch code/math</label>
+
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,39 @@
+// Popup script for ChatGPT RTL Fixer (FA/EN)
+// Reads and updates settings in chrome.storage via the service worker.
+
+let currentHost;
+const enabledEl = document.getElementById('enabled');
+const modeEl = document.getElementById('mode');
+const skipEl = document.getElementById('skipCode');
+
+chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+  const tab = tabs[0];
+  currentHost = new URL(tab.url).hostname;
+  chrome.runtime.sendMessage({ type: 'getSettings', host: currentHost }, (res) => {
+    const s = res.settings;
+    enabledEl.checked = s.enabled;
+    modeEl.value = s.mode;
+    skipEl.checked = s.skipCode;
+    if (!s.globalEnabled) {
+      enabledEl.disabled = true;
+      modeEl.disabled = true;
+      skipEl.disabled = true;
+    }
+  });
+});
+
+enabledEl.addEventListener('change', () => {
+  chrome.runtime.sendMessage({
+    type: 'setSettings',
+    host: currentHost,
+    enabled: enabledEl.checked,
+  });
+});
+
+modeEl.addEventListener('change', () => {
+  chrome.runtime.sendMessage({ type: 'setSettings', mode: modeEl.value });
+});
+
+skipEl.addEventListener('change', () => {
+  chrome.runtime.sendMessage({ type: 'setSettings', skipCode: skipEl.checked });
+});

--- a/service_worker.js
+++ b/service_worker.js
@@ -1,0 +1,85 @@
+// Service worker for ChatGPT RTL Fixer (FA/EN)
+// Handles global toggle, storage, and messaging between popup and content scripts.
+
+const DEFAULT_SETTINGS = {
+  globalEnabled: true,
+  mode: 'auto',
+  skipCode: true,
+  enabledSites: {},
+};
+
+let settings = { ...DEFAULT_SETTINGS };
+
+chrome.storage.sync.get(DEFAULT_SETTINGS, (res) => {
+  settings = { ...settings, ...res };
+});
+
+function isEnabled(host) {
+  return settings.globalEnabled && settings.enabledSites[host] !== false;
+}
+
+function updateTab(tab) {
+  if (!tab || !tab.url) return;
+  const host = new URL(tab.url).hostname;
+  if (!['chat.openai.com', 'chatgpt.com'].includes(host)) return;
+  const enabled = isEnabled(host);
+  chrome.tabs.sendMessage(tab.id, {
+    type: 'settings',
+    settings: { enabled, mode: settings.mode, skipCode: settings.skipCode },
+  });
+}
+
+function updateAllTabs() {
+  chrome.tabs.query(
+    { url: ['https://chat.openai.com/*', 'https://chatgpt.com/*'] },
+    (tabs) => tabs.forEach(updateTab)
+  );
+}
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.type === 'getSettings') {
+    const enabled = isEnabled(msg.host);
+    sendResponse({
+      settings: {
+        enabled,
+        mode: settings.mode,
+        skipCode: settings.skipCode,
+        globalEnabled: settings.globalEnabled,
+      },
+    });
+    return true;
+  }
+  if (msg.type === 'setSettings') {
+    if (msg.host && typeof msg.enabled === 'boolean') {
+      settings.enabledSites[msg.host] = msg.enabled;
+      chrome.storage.sync.set({ enabledSites: settings.enabledSites });
+    }
+    if (msg.mode) {
+      settings.mode = msg.mode;
+      chrome.storage.sync.set({ mode: settings.mode });
+    }
+    if (typeof msg.skipCode === 'boolean') {
+      settings.skipCode = msg.skipCode;
+      chrome.storage.sync.set({ skipCode: settings.skipCode });
+    }
+    updateAllTabs();
+  }
+});
+
+chrome.commands.onCommand.addListener((cmd) => {
+  if (cmd === 'toggle-extension') {
+    settings.globalEnabled = !settings.globalEnabled;
+    chrome.storage.sync.set(
+      { globalEnabled: settings.globalEnabled },
+      updateAllTabs
+    );
+  }
+});
+
+chrome.tabs.onActivated.addListener((info) => {
+  chrome.tabs.get(info.tabId, updateTab);
+});
+
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (changeInfo.status === 'complete') updateTab(tab);
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,6 @@
+/* ChatGPT RTL Fixer (FA/EN) - minimal injected styles
+   Ensures isolation of wrapped text runs. */
+
+bdi[dir] {
+  unicode-bidi: isolate;
+}


### PR DESCRIPTION
## Summary
- add Manifest V3 extension fixing mixed Persian/Arabic and English text direction on ChatGPT
- include popup to toggle per-site settings and modes
- service worker manages global state and keyboard shortcut
- remove icon assets and icon references

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688dacb4d604833093d686618e969de2